### PR TITLE
change `graphql-import` to a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Webpack loader for [`graphql-import`](https://github.com/graphcool/graphql-impor
 ## Install
 
 ```console
-yarn add --dev graphql-import-loader
+yarn add --dev graphql-import graphql-import-loader
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -28,17 +28,19 @@
     "pretest": "npm run build",
     "test": "jest"
   },
-  "dependencies": {
-    "graphql-import": "^0.4.5"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/jest": "^22.1.4",
     "@types/node": "^9.4.6",
-    "ts-jest": "^22.4.1",
     "graphql": "^0.13.1",
+    "graphql-import": "^0.4.5",
     "jest": "^22.4.2",
     "memory-fs": "^0.4.1",
+    "ts-jest": "^22.4.1",
     "typescript": "^2.7.2",
-    "webpack": "^4.0.1"
+    "webpack": "^4.1.0"
+  },
+  "peerDependencies": {
+    "graphql-import": "^0.3.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,5 @@ export default function(source) {
 
   this.cacheable()
 
-  callback(null, `module.exports = \`${importSchema(source)}\``)
+  callback(null, `module.exports = \`${importSchema(source).replace(/`/g, '\\`')}\``)
 }

--- a/test/fixtures/a.graphql
+++ b/test/fixtures/a.graphql
@@ -1,3 +1,6 @@
+"""
+Comment with escaped `backticks`
+"""
 type A {
   id: ID!
   valueA: String

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -14,6 +14,9 @@ const complex = `module.exports = \`type Complex {
   d: D!
 }
 
+"""
+Comment with escaped \\\`backticks\\\`
+"""
 type A {
   id: ID!
   valueA: String


### PR DESCRIPTION
This removes the dependency on `graphql-import` to allow independent versioning between the loader and transformer. I ran the tests using `0.2.0`, `0.3.0` and `0.4.0`. Version `0.2.0` was the only one that failed