### PR TITLE
fix circleci badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # graphql-import-loader
 
-[![CircleCI](https://circleci.com/gh/graphcool/graphql-import-loader.svg?style=shield)](https://circleci.com/gh/graphcool/graphql-import-loader) [![npm version](https://badge.fury.io/js/graphql-import-loader.svg)](https://badge.fury.io/js/graphql-import-loader)
+[![CircleCI](https://circleci.com/gh/prisma/graphql-import-loader.svg?style=shield)](https://circleci.com/gh/graphcool/graphql-import-loader) [![npm version](https://badge.fury.io/js/graphql-import-loader.svg)](https://badge.fury.io/js/graphql-import-loader)
 
 
 Webpack loader for [`graphql-import`](https://github.com/graphcool/graphql-import)


### PR DESCRIPTION
The link was pointing to https://circleci.com/gh/graphcool/graphql-import-loader