### PR TITLE
add testURL to jest config so tests don't break

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # graphql-import-loader
 
-[![CircleCI](https://circleci.com/gh/graphcool/graphql-import-loader.svg?style=shield)](https://circleci.com/gh/graphcool/graphql-import-loader) [![npm version](https://badge.fury.io/js/graphql-import-loader.svg)](https://badge.fury.io/js/graphql-import-loader)
+[![CircleCI](https://circleci.com/gh/prisma/graphql-import-loader.svg?style=shield)](https://circleci.com/gh/graphcool/graphql-import-loader) [![npm version](https://badge.fury.io/js/graphql-import-loader.svg)](https://badge.fury.io/js/graphql-import-loader)
 
 
 Webpack loader for [`graphql-import`](https://github.com/graphcool/graphql-import)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "testURL": "http://localhost/",
   "roots": [
     "<rootDir>"
   ],


### PR DESCRIPTION
This was the output of `npm test`
```bash
> graphql-import-loader@0.0.0-semantic-release pretest /Users/dsanchez/projects/graphql-import-loader                                                                                         
> npm run build


> graphql-import-loader@0.0.0-semantic-release build /Users/dsanchez/projects/graphql-import-loader                                                                                           
> rm -rf dist && tsc -d


> graphql-import-loader@0.0.0-semantic-release test /Users/dsanchez/projects/graphql-import-loader                                                                                            
> jest

 FAIL  test/loader.test.ts
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)                                                                                    
          at Array.forEach (<anonymous>)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.507s
Ran all test suites.
npm ERR! Test failed.  See above for more details.
```

And after adding `"testURL": "http://localhost/"` to the jest config, the tests passed as expected