### PR TITLE
feat(loader): Use relative path inside SDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,25 @@ yarn add --dev graphql-import-loader
 
 ## Usage
 
-Resolve GraphQL file import statements as a string. See the tests for more details
+Resolve GraphQL file import statements with relative paths. See the tests for more details
+
+```
+.
+├── src
+│   ├── index.js
+│   └── schema
+│       ├── a.graphql
+│       ├── b.graphql
+│       ├── main.graphql
+│       └── subdir
+│           └── cd.graphql
+└── webpack.config.js
+```
 
 ```graphql
-# import { A } from 'src/schema/a.graphql'
-# import { B } from 'src/schema/b.graphql'
-# import { C, D } from 'src/schema/cd.graphql'
+# import { A } from './a.graphql'
+# import { B } from './b.graphql'
+# import { C, D } from './subdir/cd.graphql'
 
 type Complex  {
   id: ID!
@@ -30,7 +43,7 @@ type Complex  {
 ```
 
 ```js
-import typeDefs from './schema.graphql'
+import typeDefs from './schema/main.graphql'
 ```
 
 ```js

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
     "js",
     "ts",
     "node"
-  ]
+  ],
+  "testEnvironment": "node"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,11 @@ import { importSchema } from 'graphql-import'
 
 export default function(source) {
   const callback = this.async();
+  const isFileRegex = /\.graphql$/i
 
   this.cacheable()
 
-  callback(null, `module.exports = \`${importSchema(source).replace(/`/g, '\\`')}\``)
+  const sdl = importSchema(isFileRegex.test(this.resource) ? this.resource : source)
+
+  callback(null, `module.exports = \`${sdl.replace(/`/g, '\\`')}\``)
 }

--- a/test/fixtures/complex.graphql
+++ b/test/fixtures/complex.graphql
@@ -1,6 +1,6 @@
-# import { A } from 'test/fixtures/a.graphql'
-# import { B } from 'test/fixtures/b.graphql'
-# import { C D } from 'test/fixtures/cd.graphql'
+# import { A } from './a.graphql'
+# import { B } from './b.graphql'
+# import { C D } from './cd.graphql'
 
 type Complex  {
   id: ID!


### PR DESCRIPTION
Use the file path instead of file content to import schema. Set Jest's environment to node
to avoid the error with jsdom's localStorage, see facebook/jest#6766 and jsdom/jsdom#2304.

BREAKING CHANGE: Use absolute path inside DSL won't work anymore, but now will be the same
behavior of `graphql-import` dealing with paths.

Fix prisma/graphql-import-loader#10